### PR TITLE
Minor updates and make tests/cufinufft work with actual cufinufft

### DIFF
--- a/PybindGPU/backend.cu
+++ b/PybindGPU/backend.cu
@@ -195,7 +195,7 @@ PYBIND11_MODULE(backend, m) {
         );
 
     m.attr("major_version")   = py::int_(0);
-    m.attr("minor_version")   = py::int_(1);
+    m.attr("minor_version")   = py::int_(2);
     m.attr("release_version") = py::int_(0);
 
     // Let the user know that this backend has been compiled _with_ CUDA support

--- a/PybindGPU/backend.cu
+++ b/PybindGPU/backend.cu
@@ -154,6 +154,7 @@ PYBIND11_MODULE(backend, m) {
                 return s;
             }
         )
+#ifndef USE_HIP
         .def("uuid",
             [](DeviceProperties & a) {
                 std::string s = mem_to_string(
@@ -162,6 +163,7 @@ PYBIND11_MODULE(backend, m) {
                 return s;
             }
         )
+#endif
         .def("pciBusID",
             [](DeviceProperties & a) {
                 return a.get()->pciBusID;
@@ -193,7 +195,7 @@ PYBIND11_MODULE(backend, m) {
         );
 
     m.attr("major_version")   = py::int_(0);
-    m.attr("minor_version")   = py::int_(2);
+    m.attr("minor_version")   = py::int_(1);
     m.attr("release_version") = py::int_(0);
 
     // Let the user know that this backend has been compiled _with_ CUDA support

--- a/clean.sh
+++ b/clean.sh
@@ -2,3 +2,4 @@
 
 _dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 rm -rf ${_dir}/PybindGPU.egg-info ${_dir}/build ${_dir}/dist
+rm -rf ${_dir}/PybindGPU/backend.cpython* ${_dir}/PybindGPU/__pycache__

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
 
     setup(
         name="PybindGPU",
-        version="0.2.0",
+        version="0.1.1",
         author="Johannes Blaschke",
         author_email="johannes@blaschke.science",
         description="",

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
 
     setup(
         name="PybindGPU",
-        version="0.1.1",
+        version="0.2.0",
         author="Johannes Blaschke",
         author_email="johannes@blaschke.science",
         description="",

--- a/test/ctypes/Makefile.summit
+++ b/test/ctypes/Makefile.summit
@@ -1,17 +1,14 @@
 CXX      := g++
-NVCXX    := hipcc
+NVCXX    := nvcc
 CXXSTD   := -std=c++14
-CXXFLAGS := $(CXXSTD) -DUSE_HIP -O3 --amdgpu-target=gfx90a -I.
-NVOPTS   := -fPIC -fgpu-rdc
-LDFLAGS  := -lhip
+CXXFLAGS := $(CXXSTD) -O3 -arch=sm_70 -I.
+NVOPTS   := --compiler-options -fPIC 
 INCLUDES := -I../../PybindGPU -I../../PybindGPU/include
 
 all: test_ctypes.so
-
 
 %.so: %.cu
 	$(NVCXX) -shared $(CXXFLAGS) $(NVOPTS) $(INCLUDES) $< -o $@
 
 clean:
 	rm *.so
-

--- a/test/cufinufft/test_cufinufft_pygpu.py
+++ b/test/cufinufft/test_cufinufft_pygpu.py
@@ -1,7 +1,8 @@
 from sys import path
 
 import numpy as np
-import PybindGPU as gpuarray
+import PybindGPU
+import PybindGPU.gpuarray as gpuarray
 
 from cufinufft import cufinufft
 
@@ -15,6 +16,7 @@ def _test_type1(dtype, shape=(16, 16, 16), M=4096, tol=1e-3):
 
     k = utils.gen_nu_pts(M, dim=dim).astype(dtype)
     c = utils.gen_nonuniform_data(M).astype(complex_dtype)
+
 
     k_gpu = gpuarray.to_gpu(k)
     c_gpu = gpuarray.to_gpu(c)

--- a/test/device/get_device_properties.py
+++ b/test/device/get_device_properties.py
@@ -9,7 +9,7 @@ for i in range(n_device):
     prop = PybindGPU.cudaDeviceProp(i)
     print(f"Device {i}:")
     print(f" | name = {prop.name()}")
-    print(f" | uuid = {prop.uuid()}")
+    #print(f" | uuid = {prop.uuid()}")
     print(f" | pciBusID = {prop.pciBusID()}")
     print(f" | pciDeviceID = {prop.pciDeviceID()}")
     print(f" `-pciDomainID = {prop.pciDomainID()}")

--- a/test/device/get_device_properties.py
+++ b/test/device/get_device_properties.py
@@ -9,7 +9,8 @@ for i in range(n_device):
     prop = PybindGPU.cudaDeviceProp(i)
     print(f"Device {i}:")
     print(f" | name = {prop.name()}")
-    #print(f" | uuid = {prop.uuid()}")
+    # Awaits ifndef kind of condition for HIP
+    #print(f" | uuid = {prop.uuid()}") 
     print(f" | pciBusID = {prop.pciBusID()}")
     print(f" | pciDeviceID = {prop.pciDeviceID()}")
     print(f" `-pciDomainID = {prop.pciDomainID()}")


### PR DESCRIPTION
Hi Johannes,

1. We talked about adding `ifndef` in `backend.cu` - this PR has that. 
2. I also edited the test in `cufinufft` so that it will actaully work with an installed cufinufft python binding.
3. `clean.sh` should include `.so` files (a deeper clean)