### PR TITLE
add constructor from python ptr; fix shape export

### DIFF
--- a/PybindGPU/__init__.py
+++ b/PybindGPU/__init__.py
@@ -1,2 +1,2 @@
 from .backend import *
-from .gpuarray import SUPPORTED_DTYPES, GPUArray, to_gpu
+from .gpuarray import SUPPORTED_DTYPES, GPUArray, to_gpu, Allocator

--- a/PybindGPU/device_array.h
+++ b/PybindGPU/device_array.h
@@ -128,8 +128,8 @@ class DeviceArray {
             host_ptr = reinterpret_cast<T *>(host_addr);
             device_ptr = reinterpret_cast<T *>(device_addr);
             // allocation status
-            host_allocated = true;
-            device_allocated = true;
+            host_allocated = false;
+            device_allocated = false;
         };
 
         ~DeviceArray() {
@@ -148,7 +148,10 @@ class DeviceArray {
         }
 
         void to_device() {
-            if (!device_allocated) return;
+            // FIXME: Below line is commented out until future fix.
+            // CAUSE: With allocator, divice memory is not owned by this class
+            // but we still need to be able to copy to and from this memory.   
+            //if (!device_allocated) return;
 
             status = cudaMemcpy(
                 device_ptr, host_ptr, m_size*sizeof(T), cudaMemcpyHostToDevice
@@ -156,7 +159,8 @@ class DeviceArray {
         }
 
         void to_host() {
-            if (!device_allocated) return;
+            // FIXME: see to_device() 
+            //if (!device_allocated) return;
 
             status = cudaMemcpy(
                 host_ptr, device_ptr, m_size*sizeof(T), cudaMemcpyDeviceToHost

--- a/PybindGPU/gpuarray.py
+++ b/PybindGPU/gpuarray.py
@@ -12,6 +12,29 @@ class UnsupportedDataType(Exception):
     def __init__(self, message):
         super().__init__(message)
 
+class Allocator:
+    def __init__(self, data, host_data=None):
+        if isinstance(data, GPUArray):
+            self.data = data
+            self._shape = data.shape
+            self._dtype = data.dtype.name
+        else:
+            # cupy array
+            self.data = data.data
+            self._shape = data.shape
+            self._dtype = data.dtype.name
+        if host_data is not None:
+            self.host_data = host_data
+        else:
+            # Creates a numpy array corresponds to this gpuarray (for host_ptr)
+            self.host_data = np.empty(self._shape, dtype=data.dtype)
+        self._host_ptr = self.host_data.ctypes.data
+
+    def ptr(self):
+        return self.data.ptr
+    def host_ptr(self):
+        return self._host_ptr
+
 
 class GPUArray(object):
     def __init__(self, *args, **kwargs):
@@ -68,7 +91,10 @@ class GPUArray(object):
                 backend, "DeviceArray_" + self._dtypestr
             )
             if self._has_allocator:
-                self._device_array = array_constructor(self._allocator.ptr(), a)
+                if hasattr(self._allocator, '_host_ptr'):
+                    self._device_array = array_constructor(self._allocator.host_ptr(), self._allocator.ptr(), a)
+                else:
+                    self._device_array = array_constructor(self._allocator.ptr(), a)
             else:
                 self._device_array = array_constructor(a)
 
@@ -160,6 +186,9 @@ class GPUArray(object):
 
     def to_device(self):
         self._device_array.to_device()
+
+    def set(self, idx, val):
+        self._device_array.set(idx, val)
 
 
     def __getitem__(self, index):

--- a/PybindGPU/gpuarray.py
+++ b/PybindGPU/gpuarray.py
@@ -91,10 +91,7 @@ class GPUArray(object):
                 backend, "DeviceArray_" + self._dtypestr
             )
             if self._has_allocator:
-                if hasattr(self._allocator, '_host_ptr'):
-                    self._device_array = array_constructor(self._allocator.host_ptr(), self._allocator.ptr(), a)
-                else:
-                    self._device_array = array_constructor(self._allocator.ptr(), a)
+                self._device_array = array_constructor(self._allocator.host_ptr(), self._allocator.ptr(), a)
             else:
                 self._device_array = array_constructor(a)
 
@@ -103,7 +100,8 @@ class GPUArray(object):
                 "input must either a numpy array -- or a list, or a tuple"
             )
 
-        self._device_array.allocate()
+        if not self._has_allocator:
+            self._device_array.allocate()
 
 
     @property

--- a/test/allocator/test_allocator_import.py
+++ b/test/allocator/test_allocator_import.py
@@ -1,0 +1,54 @@
+import PybindGPU  as gpuarray
+import numpy as np
+
+
+print("")
+print("Testing GPUArray constructor with PybindGPU GPUArray")
+print("==============")
+
+# Send a numpy array to the device
+k = np.arange(6).reshape(3,2)
+k_gpu = gpuarray.to_gpu(k)
+print(f'{k=} {type(k)=} {k.ctypes.data=}')
+print(f'{k_gpu=} {type(k_gpu)=} {k_gpu.ptr=} {k_gpu.shape=}')
+# Create another gpuarray pointing to the first gpuarray
+j_gpu = gpuarray.GPUArray(allocator=gpuarray.Allocator(k_gpu))
+# Set j_gpu to something else
+j_gpu.set(0, 43)
+j_gpu.set(1, 44)
+j_gpu.set(8, 45)
+# j is another numpy array allocated automatically by gpuarray.Allocator
+j = j_gpu.get()
+print(f'{j=} {type(j)=} {j.ctypes.data=}')
+print(f'{k=} {type(k)=} {k.ctypes.data=}')
+# Check answers
+known_k = np.array([0,1,2,3,4,5], dtype=np.int64).reshape(3,2)
+known_j = np.array([43,44,2,3,4,5], dtype=np.int64).reshape(3,2)
+assert np.array_equal(k, known_k)
+assert np.array_equal(j, known_j)
+
+try:
+    import cupy
+    cupy_available = True
+except Exception:
+    cupy_available = False
+
+if cupy_available:
+    print("")
+    print("Testing GPUArray constructor with cupy array")
+    print("==============")
+    k=cupy.arange(6).reshape(3,2)
+    k_gpu=gpuarray.GPUArray(allocator=gpuarray.Allocator(k))
+    print(f'{k=} {type(k)=} {k.data.ptr=}')
+    print(f'{k_gpu=} {type(k_gpu)=} {k_gpu.ptr=} {k_gpu.shape=}')
+    k_gpu.set(0, 43)
+    k_gpu.set(1, 44)
+    j = k_gpu.get()
+    print(f'{j=} {type(j)=} {j.ctypes.data=}')
+    print(f'{k=} {type(k)=} {k.data.ptr=}')
+    known_j = np.array([43,44,2,3,4,5], dtype=np.int64).reshape(3,2)
+    assert np.array_equal(k.get(), known_j)
+    assert np.array_equal(j, known_j)
+else:
+    print(f'Skip Testing GPUArray constructor with cupy array: cupy is not available')
+

--- a/test/allocator/test_allocator_import.py
+++ b/test/allocator/test_allocator_import.py
@@ -19,13 +19,13 @@ j_gpu.set(1, 44)
 j_gpu.set(8, 45)
 # j is another numpy array allocated automatically by gpuarray.Allocator
 j = j_gpu.get()
-print(f'{j=} {type(j)=} {j.ctypes.data=}')
+print(f'{j[0,:]=} {type(j)=} {j.ctypes.data=}')
 print(f'{k=} {type(k)=} {k.ctypes.data=}')
-# Check answers
+# Check answers (k shouldn't change)
 known_k = np.array([0,1,2,3,4,5], dtype=np.int64).reshape(3,2)
-known_j = np.array([43,44,2,3,4,5], dtype=np.int64).reshape(3,2)
+known_j = np.array([43,44], dtype=np.int64)
 assert np.array_equal(k, known_k)
-assert np.array_equal(j, known_j)
+assert np.array_equal(j[0,:], known_j)
 
 try:
     import cupy


### PR DESCRIPTION
This adds `GPUArray` constructor from python pointer. A facilitator class `gpuarray.Allocator` input is used to setup attributes and creates corresponding host array (numpy) if needed (for `host_ptr` when `.get()` is called). 

Member function `shape()` is fixed for automatically casting `std::vector` to python list.    